### PR TITLE
switch pandas -> arrow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "duckdb==1.2.1",
-    "snowflake-connector-python[pandas]==3.14.0",
+    "snowflake-connector-python==3.14.0",
     "cryptography==44.0.2",
     "PyYAML==6.0",
     "typer==0.15.2",
     "rich==14.0.0",
-    "pandas==2.2.2"
+    "pyarrow==16.1.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request includes several changes to migrate from using Pandas to PyArrow for data extraction and processing in the `warehouse_to_go` project. The changes involve updating dependencies, modifying import statements, and refactoring functions to handle PyArrow tables instead of Pandas DataFrames.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R18): Replaced `pandas` with `pyarrow` in the dependencies list and removed the `pandas` extra from the `snowflake-connector-python` dependency.

Import statement updates:

* [`warehouse_to_go/extractor/snowflake_extractor.py`](diffhunk://#diff-f7cdf37c243e1b5779adbd9e2ceb5d8a92c9cbc39d1e43ab1fa91e92c9112604L3-L10): Replaced imports of `pandas` and `numpy` with `pyarrow` and `pyarrow.parquet`.

Function refactoring:

* [`warehouse_to_go/extractor/snowflake_extractor.py`](diffhunk://#diff-f7cdf37c243e1b5779adbd9e2ceb5d8a92c9cbc39d1e43ab1fa91e92c9112604L91-R103): Replaced the `_convert_df_for_duckdb` function with `_convert_arrow_for_duckdb` to handle PyArrow tables and convert them to types compatible with DuckDB.
* [`warehouse_to_go/extractor/snowflake_extractor.py`](diffhunk://#diff-f7cdf37c243e1b5779adbd9e2ceb5d8a92c9cbc39d1e43ab1fa91e92c9112604L172-R197): Updated the `extract_tables` function to fetch data as Arrow tables instead of Pandas DataFrames and process them accordingly.

Other changes:

* [`warehouse_to_go/extractor/snowflake_extractor.py`](diffhunk://#diff-f7cdf37c243e1b5779adbd9e2ceb5d8a92c9cbc39d1e43ab1fa91e92c9112604L120): Removed the unused `results` dictionary from the `extract_tables` function.